### PR TITLE
修改USAGE中-l参数说明

### DIFF
--- a/USAGE
+++ b/USAGE
@@ -35,7 +35,10 @@
 	-n 指定job名称
 
       4.查看job
-        ./lpts.py -l 
+        ./lpts.py -l -f jobs.xml
+	参数说明：
+	-l 列出指定任务文件中的任务
+        -f 指定jobs.xml,不指定时，程序将自动指定为db/jobs.xml 
 	示例：
       JOBBID           JOBNAME                     resultsDB                        STATUS
 ------------------------------------------------------------------------------------------


### PR DESCRIPTION
USAGE中-l参数未作说明可以使用-f参数，容易引起误解“只能使用db/jobs.xml”，在第3步创建测试任务的参数中使用-f生成了jobs.xml，但第四步未使用jobs.xml